### PR TITLE
[FEATURE] Modified 'path' imports

### DIFF
--- a/app/app/urls.py
+++ b/app/app/urls.py
@@ -22,12 +22,12 @@ from drf_spectacular.views import (
 )
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('api/schema/', SpectacularAPIView.as_view(), name='api-schema'),
+    path("admin/", admin.site.urls),
+    path("api/schema/", SpectacularAPIView.as_view(), name="api-schema"),
     path(
-        'api/docs/',
-        SpectacularSwaggerView.as_view(url_name='api-schema'),
-        name='api-docs'
+        "api/docs/",
+        SpectacularSwaggerView.as_view(url_name="api-schema"),
+        name="api-docs",
     ),
     path("api/users/", include("user.urls"), name="users-resource"),
     path("api/subjects/", include("subject.urls"), name="subject-resource"),

--- a/app/subject/urls.py
+++ b/app/subject/urls.py
@@ -1,9 +1,9 @@
-from django.urls import path
+from rest_framework.urls import path
 from subject.views import SubjectsListView, SubjectDetailView
 
-app_name = 'subject'
+app_name = "subject"
 
 urlpatterns = [
-    path('', SubjectsListView.as_view(), name='subject-list'),
-    path('<str:code>', SubjectDetailView.as_view(), name='subject-detail'),
+    path("", SubjectsListView.as_view(), name="subject-list"),
+    path("<str:code>", SubjectDetailView.as_view(), name="subject-detail"),
 ]

--- a/app/user/urls.py
+++ b/app/user/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from rest_framework.urls import path
 from user import views
 
 app_name = "user"


### PR DESCRIPTION
As suggested on #15, `path` imports where changed from `django.urls` to `rest_framework.urls`.