### PR TITLE
[Feature] Add read only fields to serializers

### DIFF
--- a/app/core/models.py
+++ b/app/core/models.py
@@ -107,7 +107,7 @@ class Selection(models.Model):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE
     )
-    created_on = models.DateTimeField(auto_now_add=True)
+    created_on = models.DateTimeField(auto_now_add=True, editable=False)
     modified_on = models.DateTimeField(auto_now=True)
 
     def __str__(self) -> str:

--- a/app/selection/serializers.py
+++ b/app/selection/serializers.py
@@ -10,7 +10,7 @@ class SelectionSerializer(ModelSerializer):
     class Meta:
         model = SelectionModel
         fields = "__all__"
-        read_only_fields = ["id"]
+        read_only_fields = ["id", "created_on"]
 
 
 class SubjectSerializer(ModelSerializer):

--- a/app/selection/serializers.py
+++ b/app/selection/serializers.py
@@ -17,6 +17,7 @@ class SubjectSerializer(ModelSerializer):
     class Meta:
         model = Subject
         fields = "__all__"
+        read_only_fields = ["id"]
 
 
 class SubjectSectionSerializer(ModelSerializer):
@@ -35,6 +36,7 @@ class SubjectSectionSerializer(ModelSerializer):
             "professor",
             "taken",
         ]
+        read_only_fields = ["id"]
 
     def run_validation(self, data):
         super().run_validation(data)

--- a/app/subject/serializers.py
+++ b/app/subject/serializers.py
@@ -6,3 +6,4 @@ class SubjectSerializer(serializers.ModelSerializer):
     class Meta:
         model = SubjectModel
         fields = "__all__"
+        read_only_fields = ["id"]

--- a/app/user/serializers.py
+++ b/app/user/serializers.py
@@ -20,10 +20,13 @@ class UserSerializer(serializers.ModelSerializer):
             "email",
         ]
         extra_kwargs = {
+            "id": {
+                "read_only": True,
+            },
             "password": {
                 "write_only": True,
                 "min_length": 8,
-            }
+            },
         }
 
     def create(self, validated_data):


### PR DESCRIPTION
As suggested in #14:

- Added read-only fields to serializers
- Selection created_on field setted as non editable
- Marked SelectionSerializer created_on field as read-only
